### PR TITLE
bootstrap: working app

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -12,5 +12,5 @@ serde_derive = "1.0.39"
 serde_json = "1.0.15"
 reqwest = "0.8.5"
 clap = "2.31.2"
-slog = { version = "2.2.3", features = ["max_level_trace", "release_max_level_debug"] }
+slog = { version = "2.2.3", features = ["max_level_trace", "release_max_level_trace"] }
 sloggers = "0.2.6"

--- a/app/src/bb_api/mod.rs
+++ b/app/src/bb_api/mod.rs
@@ -6,7 +6,6 @@ pub mod repositories;
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub struct Paginated<T> {
-    pub pagelen: u32,
     pub values: Vec<T>,
     pub next: Option<String>,
 }

--- a/app/src/bb_api/repositories/username/repo_slug/pullrequests/mod.rs
+++ b/app/src/bb_api/repositories/username/repo_slug/pullrequests/mod.rs
@@ -10,6 +10,7 @@ pub struct PullRequest {
     pub title: String,
     pub state: String,
     pub links: PullRequestLinks,
+    pub author: PullRequestUser,
 }
 
 #[derive(Deserialize, PartialEq, Debug)]
@@ -22,4 +23,9 @@ pub struct PullRequestLinks {
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct Href {
     pub href: String,
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct PullRequestUser {
+    pub username: String,
 }

--- a/app/src/bb_api/repositories/username/repo_slug/pullrequests/pull_request_id/activity.rs
+++ b/app/src/bb_api/repositories/username/repo_slug/pullrequests/pull_request_id/activity.rs
@@ -11,6 +11,7 @@ use serde_json::value::Value;
 pub enum ActivityItem {
     Comment { comment: Comment },
     Update { update: Value },
+    Approval { approval: Approval },
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]
@@ -18,6 +19,11 @@ pub struct Comment {
     pub id: u32,
     pub parent: Option<CommentParent>,
     pub content: CommentContent,
+    pub user: CommentUser,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct Approval {
     pub user: CommentUser,
 }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -20,9 +20,12 @@ use gatekeeper::bb_api::repositories::username::repo_slug::pullrequests::
 use gatekeeper::bb_api::repositories::username::repo_slug::pullrequests::PullRequest;
 use gatekeeper::get_commands;
 
+use std::collections::HashMap;
+use std::collections::hash_map::RandomState;
+
 fn main() {
     let mut logger = sloggers::terminal::TerminalLoggerBuilder::new();
-    logger.level(sloggers::types::Severity::Debug);
+    logger.level(sloggers::types::Severity::Trace);
     logger.destination(sloggers::terminal::Destination::Stderr);
     let logger = logger.build().unwrap();
 
@@ -57,23 +60,23 @@ fn main() {
                 .hide_env_values(true),
         )
         .arg(
-            Arg::with_name("repo_slug")
-                .long("--bitbucket-repo-slug")
+            Arg::with_name("repo_slugs")
+                .long("--bitbucket-repo-slugs")
                 .takes_value(true)
                 .required(true)
-                .env("BITBUCKET_REPO_SLUG")
+                .env("BITBUCKET_REPO_SLUGS")
                 .hide_env_values(true),
         )
         .get_matches();
 
-    debug!(logger, "Retrieving bitbucket_username");
+    trace!(logger, "Retrieving bitbucket_username");
     let bitbucket_username = app_args.value_of("bitbucket_username").unwrap();
-    debug!(logger, "Retrieving bitbucket_password");
+    trace!(logger, "Retrieving bitbucket_password");
     let bitbucket_password = app_args.value_of("bitbucket_password").unwrap();
-    debug!(logger, "Retrieving repo_owner");
+    trace!(logger, "Retrieving repo_owner");
     let repo_owner = app_args.value_of("repo_owner").unwrap();
-    debug!(logger, "Retrieving repo_slug");
-    let repo_slug = app_args.value_of("repo_slug").unwrap();
+    trace!(logger, "Retrieving repo_slug");
+    let repo_slugs = app_args.value_of("repo_slugs").unwrap();
 
     debug!(logger, "Creating reqwest::Client");
     let client = reqwest::Client::new();
@@ -87,29 +90,69 @@ fn main() {
         req_builder
     };
 
-    let repo_base_url = format!(
-        "https://api.bitbucket.org/2.0/repositories/{}/{}",
-        repo_owner, repo_slug
-    );
-    let repo_url_prs = format!("{}/pullrequests/", repo_base_url);
+    for repo_slug in repo_slugs.split(',') {
+        println!("{}", repo_slug);
+        println!("------------------------------------------------------------------------");
 
-    let mut prs_first = reqwest_get(repo_url_prs.as_str()).send().unwrap();
-    let prs_first_txt = prs_first.text().unwrap();
-    let prs_first: Paginated<PullRequest> = serde_json::from_str(prs_first_txt.as_str()).unwrap();
-    let prs = unpaginate(prs_first, &reqwest_get, &logger).unwrap();
+        debug!(logger, "Building URLs");
+        let repo_base_url = format!(
+            "https://api.bitbucket.org/2.0/repositories/{}/{}",
+            repo_owner, repo_slug
+        );
+        let repo_url_prs = format!("{}/pullrequests/", repo_base_url);
 
-    debug!(logger, "PRs: {:?}", prs);
+        debug!(logger, "Obtaining first page of PR list");
+        let mut prs_first = reqwest_get(repo_url_prs.as_str()).send().unwrap();
+        debug!(logger, "Obtaining all pages or PR list");
+        trace!(logger, "Getting PRs list first page text");
+        let prs_first_txt = prs_first.text().unwrap();
+        trace!(logger, "Response: {}", prs_first_txt);
+        trace!(logger, "Deserializing PRs list first page text");
+        let prs_first: Paginated<PullRequest> =
+            serde_json::from_str(prs_first_txt.as_str()).unwrap();
+        trace!(logger, "Getting remaining pages of PRs list");
+        let prs = unpaginate(prs_first, &reqwest_get, &logger).unwrap();
 
-    for pr in &prs {
-        debug!(logger, "PR id: {} title: {}", pr.id, pr.title);
+        debug!(logger, "PRs: {:?}", prs);
 
-        let mut pr_first = reqwest_get(pr.links.activity.href.as_str()).send().unwrap();
-        let pr_first_txt = pr_first.text().unwrap();
-        let pr_first: Paginated<ActivityItem> =
-            serde_json::from_str(pr_first_txt.as_str()).unwrap();
-        let pr = unpaginate(pr_first, &reqwest_get, &logger).unwrap();
-        debug!(logger, "PR: {:?}", pr);
-        let cmds = get_commands(pr);
-        debug!(logger, "Commands: {:?}", cmds);
+        for pr in &prs {
+            debug!(logger, "PR id: {} title: {}", pr.id, pr.title);
+
+            debug!(logger, "PR: {:?}", pr);
+
+            let mut pr_first = reqwest_get(pr.links.activity.href.as_str()).send().unwrap();
+            let pr_first_txt = pr_first.text().unwrap();
+            trace!(logger, "PR first text: {}", pr_first_txt);
+            let pr_first: Paginated<ActivityItem> =
+                serde_json::from_str(pr_first_txt.as_str()).unwrap();
+            let mut pr_activity = unpaginate(pr_first, &reqwest_get, &logger).unwrap();
+            pr_activity.reverse();
+            debug!(logger, "PR: {:?}", pr_activity);
+            let cmds = get_commands(pr_activity);
+            debug!(logger, "Commands: {:?}", cmds);
+
+            let mut review_status: HashMap<String, String, RandomState> = HashMap::new();
+            for user_cmd in cmds {
+                match user_cmd.command.as_str() {
+                    "\\+1" | "\\+0" | "-1" => {
+                        let vote = review_status
+                            .entry(user_cmd.user.to_string())
+                            .or_insert(String::from("0"));
+                        *vote = user_cmd.command;
+                    }
+                    _ => {}
+                }
+            }
+
+            println!("  PR {}: {}", pr.id, pr.title);
+            println!("    -- author: {}", pr.author.username);
+            println!(
+                "    -- link: https://bitbucket.org/{}/{}/pull-requests/{}",
+                repo_owner, repo_slug, pr.id
+            );
+            for (user, vote) in &review_status {
+                println!("    {}: {}", user, vote);
+            }
+        }
     }
 }

--- a/app/src/tests/bb_api/repositories/username/repo_slug/pullrequests/pull_request_id/activity/mod.rs
+++ b/app/src/tests/bb_api/repositories/username/repo_slug/pullrequests/pull_request_id/activity/mod.rs
@@ -42,7 +42,6 @@ fn deserialize_api_page_1() {
     fn cl() -> Result<(), serde_json::Error> {
         let data = example_input::api_page_1();
         let v: Paginated<ActivityItem> = serde_json::from_str(data)?;
-        assert_eq!(10, v.pagelen);
 
         let next = v.next;
         assert_eq!(Some(String::from("https://api.bitbucket.org/2.0/repositories/kgadek/test-repo/pullrequests/1/activity?ctx=foobar")), next);
@@ -66,7 +65,6 @@ fn deserialize_api_page_2() {
     fn cl() -> Result<(), serde_json::Error> {
         let data = example_input::api_page_2();
         let v: Paginated<ActivityItem> = serde_json::from_str(data)?;
-        assert_eq!(10, v.pagelen);
 
         let next = v.next;
         assert_eq!(None, next);

--- a/app/src/tests/mod.rs
+++ b/app/src/tests/mod.rs
@@ -73,7 +73,6 @@ fn mk_comment_3() -> Comment {
 fn activities_to_items_multi_nonempty() {
     let inp: Vec<Paginated<ActivityItem>> = vec![
         Paginated {
-            pagelen: 3,
             next: Some("foo".to_string()),
             values: vec![
                 ActivityItem::Comment {
@@ -88,7 +87,6 @@ fn activities_to_items_multi_nonempty() {
             ],
         },
         Paginated {
-            pagelen: 3,
             next: None,
             values: vec![
                 ActivityItem::Update {


### PR DESCRIPTION
DONE:

* Application gets params, asks BitBucket API, and outputs the following
  informations:

      foobar-repository
      ------------------------------------------------------------------------
        PR 20: Title of the PR
          -- author: kgadek
          -- link: https://bitbucket.org/owner/foobar-repository/pull-requests/20
          amnk: -1
        PR 19: Title of the PR
          -- author: amnk
          -- link: https://bitbucket.org/owner/foobar-repository/pull-requests/19
          kgadek: \+1
      bazbarfoo-repository
      ------------------------------------------------------------------------
      quux-repository
      ------------------------------------------------------------------------
        PR 1: Title of the PR
          -- author: somebody
          -- link: https://bitbucket.org/owner/quux-repository/pull-requests/1
          kgadek: \+1
          amnk: \+1

  The information above is (arguably) better than the usual dashboard on
  BitBucket [1], as allows more states: "+0" and "-1" are not present in
  PR the usual way.

TODO:

* Logging. It's gross, dirty, incomplete, ad hoc. But exists.

* Caching. This is going to be a great nuisance.  One of a test-run over
  seven repositories took 5:20 minutes (sic!), probably it got throttled
  server-side.  Moreover, BitBucket API doesn't return cache information
  in HTTP headers.
  I'm not sure what would be the best solution yet. Here are some ideas:

  - accountability: BitBucket requests return `x-render-time` header. It
    could be used to drive futher optimizations.

  - partial responses: the responses are pretty verbose, but there seems
    to be a way to reduce this size [2]. Having accountability we may be
    able to check if this helps with performance.

  - caching: there are some low-hanging fruits.  For example, if a first
    page of a response is the same as one in the past,  and the response
    contains entries from newest to oldest,  then we could retrieve next
    pages from cache.  This seems to be reasonable approach for at least
    {pr_id}/activity endpoint.
    I think the caching should be handled by external service, eg. redis
    or memcached. This will allow gatekeeper to remain persistence-less.

* Asyncs.  Having mentioned performance issues, it *seems* possible that
  using tokio/futures would introduce some performance boost.

* Refactoring. Some things are just purely ugly. This is manageable only
  at this scale of code. For example, `get_commands` starts looking like
  god-function that accumulates all logic.
  Let's refactor as long as it's still maintainable (and I have all this
  in my mental cache).

* Tests. Currently they do not make much sense, as they duplicate mostly
  serde unit-tests and not any actual implementation logic.

* Commands pre-parsing.  For example, writing `!g +1` will result in the
  "\\+1" as returned in the API. Pre-parsing would make rest of the code
  easier (less leaky abstraction).

* Output formatting.  We *may* need multiple output formatters, e.g. for
  Slack and separate for CLI usage.

* Data structures. The "swaggerization" so far was a complete failure as
  OpenAPI spec from Atlassian [3] is… bad.  So we need to probably write
  them on our own (possibly to be extracted later as a separate crate).

[1]: http://bitbucket.org/dashboard/overview
[2]: https://developer.atlassian.com/bitbucket/api/2/reference/meta/partial-response
[3]: http://api.bitbucket.org/swagger.json