### PR TITLE
meta,docs: drop "stupid" adjective

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = ["Konrad Gądek <kgadek@gmail.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/blancmanges/gatekeeper"
-description = "Gatekeeper, a stupid bitbucket bot."
+description = "Gatekeeper, a bitbucket bot."
 
 [dependencies]
 serde = "1.0.39"


### PR DESCRIPTION
We need to be serious about our repo. Can't be serious when something is
stupid, aye?

Follow up of the 40842c4c9653a18714f55ce77893ac117eefa97b