### PR TITLE
feature:votes: remember voting-time hash

### DIFF
--- a/src/bitbucket.rs
+++ b/src/bitbucket.rs
@@ -122,13 +122,14 @@ pub struct PullRequestUser {
     pub username: String,
 }
 
+#[allow(dead_code)]
 type Ignored = serde_json::value::Value;
 
 #[derive(PartialEq, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ActivityItem {
     Comment { comment: Comment },
-    Update { update: Ignored },
+    Update { update: Update },
     Approval { approval: Approval },
 }
 
@@ -164,4 +165,19 @@ pub struct Approval {
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub struct User {
     pub username: String,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct Update {
+    pub source: Source,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct Source {
+    pub commit: Commit,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct Commit {
+    pub hash: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ fn display_pr_results(res: Result<PullRequestState, (PullRequest, Error)>, logge
             println!("  PR {}: {}", pr_state.pr.id, pr_state.pr.title);
             println!("    -- author: {}", pr_state.pr.author.username);
             println!("    -- link: {}", pr_state.urls.web_url);
+            println!("    -- current_hash: {:?}", pr_state.current_hash);
             if !pr_state.labels.is_empty() {
                 println!("    -- labels: {}", pr_state.labels.iter().join(", "));
             }


### PR DESCRIPTION
BitBucket API, which is documented in most precise details ([sarcasm](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/pullrequests/activity)), returns rather empty PR description; rest of details are exposed through activity. One of these is the SHA1 checksum of the PR's branch.

On the activity list, first item will be the `Update` with `destination` pointing to merge head (usually: master branch) and `source` pointing to the current branch HEAD.  Unfortunately, it would be quite cumbersome to encode this into type system,  therefore -- as unfortunate result -- the `PullRequestState` needs to hold `current_hash: Option<String>` instead of simple `String`.

This BitBucket behavior makes _some_ sense and observations show that it is the case.  However -- this being undocumented -- I can only call this "observed behaviour". In other words: I hope they don't change it ;)

This will allow #32 to be implemented.