### PR TITLE
slog_async: increase channel/buffer size 128 -> 256

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
             .open(json_log_path)
             .unwrap();
         let drain = slog_bunyan::new(json_log_file).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
+        let drain = slog_async::Async::new(drain).chan_size(256).build().fuse();
         slog::Logger::root(
             drain,
             o!(


### PR DESCRIPTION
I was getting quite a few `AsyncError::Full`:

    {
      "msg": "slog-async: logger dropped messages due to channel overflow",
      "snip": "…",
      "count": 93
    }

The default size is 128. Doubling that value solved the problem.